### PR TITLE
Unsets Model's keyName from $itemData

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -1048,6 +1048,7 @@ class QueryBuilder extends Builder
                 // Disable any tree actions
                 $model->rawNode($model->getLft(), $model->getRgt(), $parentId);
 
+                unset($itemData[$keyName]);
                 unset($existing[$key]);
             }
 


### PR DESCRIPTION
Removes the necessity of having the model's keyName as a fillable property